### PR TITLE
Update example to use https rather than http

### DIFF
--- a/listings/intro/first-project/index.js
+++ b/listings/intro/first-project/index.js
@@ -1,8 +1,8 @@
 var CountStream = require('./countstream'); //<co id="callout-intro-countstream-index-1" />
 var countStream = new CountStream('book'); //<co id="callout-intro-countstream-index-2" />
-var http = require('http');
+var https = require('https');
 
-http.get('http://www.manning.com', function(res) { //<co id="callout-intro-countstream-index-3" />
+https.get('https://www.manning.com', function(res) { //<co id="callout-intro-countstream-index-3" />
   res.pipe(countStream); //<co id="callout-intro-countstream-index-4" />
 });
 


### PR DESCRIPTION
Update example to use https rather than http. (looks like manning.com switched to https protocol so example no longer works using `http`.)
