### PR TITLE
end of readable stream - inform consumer by passing null

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -17,3 +17,22 @@ should be
 ```js
 lineIndex = this._buffer.indexOf('\n');
 ```
+
+### End of readable stream
+
+Implicitly passing undefined as chunk to readable.push does not properly inform consumer that data output is finished.
+Pass null instead.
+
+Page 92, Listing 5.4
+
+```js
+// Done
+this.push();
+```
+
+should be
+
+```js
+// Done
+this.push(null);
+```

--- a/listings/streams/node-0.10/express.js
+++ b/listings/streams/node-0.10/express.js
@@ -13,7 +13,7 @@ function StatStream(limit) {
 StatStream.prototype._read = function(size) {
   if (this.limit === 0) {
     // Done
-    this.push();
+    this.push(null);
   } else {
     this.push(util.inspect(process.memoryUsage())); //<co id="callout-streams-express-2" />
     this.push('\n');


### PR DESCRIPTION
Implicitly passing undefined as chunk to readable.push does not properly inform consumer that data output is finished.